### PR TITLE
ADD EventBridge scheduler rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ These instructions assume you have completed all the prerequisites, and you have
     - When prompted, provide the following parameters:
         - `appfabric-data-source-s3-uri`: (Optional) The S3 uri of the AppFabric data source. For example, enter s3://MyBucket/. If specified, the solution will output sample logs to this location.
         - `kinesis-firehose-arn`: (Optional) If specified the solution will also inject records into the given Kinesis Firehose ARN
-        - `scheduler-option`: (yes/no) If yes, solution will also create a an EventBridge schedule to invoke the log generator every week on Monday at 00:00 UTC. The schedule can be changed after deployment by modifying the cron job of the EventBridge rule.
+        - `scheduler-option`: (Optional) Enter 'yes' to enable. If enabled, solution will create an EventBridge schedule to invoke the log generator every week on Monday at 00:00 UTC. The schedule can be changed after deployment by modifying the cron job of the EventBridge rule.
 
 5. Deploy CDK stacks
     - In your terminal navigate to `appfabric-sample-log-generator/cdk-stacks`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ These instructions assume you have completed all the prerequisites, and you have
     - When prompted, provide the following parameters:
         - `appfabric-data-source-s3-uri`: (Optional) The S3 uri of the AppFabric data source. For example, enter s3://MyBucket/. If specified, the solution will output sample logs to this location.
         - `kinesis-firehose-arn`: (Optional) If specified the solution will also inject records into the given Kinesis Firehose ARN
+        - `scheduler-option`: (yes/no) If yes, solution will also create a an EventBridge schedule to invoke the log generator every week on Monday at 00:00 UTC. The schedule can be changed after deployment by modifying the cron job of the EventBridge rule.
 
 5. Deploy CDK stacks
     - In your terminal navigate to `appfabric-sample-log-generator/cdk-stacks`

--- a/cdk-stacks/config.params.json
+++ b/cdk-stacks/config.params.json
@@ -14,6 +14,12 @@
             "cliFormat": "kinesis-firehose-arn",
             "description": "(Optional) If specified the solution will also inject records into the given Kinesis Firehose ARN",
             "required": false
+        },
+        {
+            "name": "schedulerOption",
+            "cliFormat": "scheduler-option",
+            "description": "(yes/no) If yes, solution will also create a an EventBridge schedule to invoke the log generator every week on Monday at 00:00 UTC. The schedule can be changed after deployment by modifying the cron job of the EventBridge rule.",
+            "required": false
         }
     ],
     "tags": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes add an EventBridge scheduler rule as an optional deployment. The deployment option is presented during parameter configuraton. If deployed, the EventBridge rule will invoke the log generator Lambda automatically every Monday at 00:00 UTC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
